### PR TITLE
fix: prevent error in validate_values when values is nil

### DIFF
--- a/lib/arke/system.ex
+++ b/lib/arke/system.ex
@@ -319,6 +319,8 @@ defmodule Arke.System.BaseParameter do
     end
   end
 
+  defp __validate_values__(opts, nil, _), do: Keyword.delete(opts, :values)
+
   defp __validate_values__(opts, %{"value" => value, "datetime" => _} = values, type)
        when not is_nil(value),
        do: __validate_values__(opts, value, type)


### PR DESCRIPTION
## Description

As per title

## Related Issue

Fixes #9
