### PR TITLE
chore(deps): add dependabot.yml to open PR for deps updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Enable version updates for mix
+  - package-ecosystem: "mix"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    # Allow up to 2 open pull requests for mix dependencies
+    open-pull-requests-limit: 2
+


### PR DESCRIPTION
## Description

With this dependabot configuration file, dependabot will be enable on project and it will open PRs when some dependencies is not updated.

For more info: https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

For documentation regarding the .yml file: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
