### PR TITLE
chore: add license job on github actions to check/fix license

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check License Header
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: apache/skywalking-eyes/header@v0.6.0
         with:
           mode: fix
       - name: Apply License Changes

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,7 +9,26 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@v0.4.0
+        with:
+          mode: fix
+      - name: Apply License Changes
+        uses: EndBug/add-and-commit@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          author_name: License Bot
+          author_email: license_bot@github.com
+          message: 'Automatic application of license header'
   test:
+    needs: license
     runs-on: ubuntu-latest
     env:
       MIX_ENV: test
@@ -19,7 +38,7 @@ jobs:
         otp: ['25.0.4']
         elixir: ['1.14.1']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,25 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Arkemis S.r.l.
+    copyright-year: '2023-2024'
+    software-name: Arke
+
+  paths-ignore:
+    - 'dist'
+    - 'apps'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.json'
+    - '**/*.yml'
+    - '**/*.yaml'
+    - '.idea/**'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'Dockerfile'
+    - '.env*'
+    - '.npmrc'
+    - '.github/**'
+    - '.gitignore'
+
+  comment: on-failure


### PR DESCRIPTION
## Description

Add license job on github actions to check/fix license. When PR is open, the job check if all files (excluded what is defined on paths-ignore of `.licenserc.yml`) have the license on header.