### PR TITLE
chore: add function to Arke.System to identify who is using

### DIFF
--- a/lib/arke/system.ex
+++ b/lib/arke/system.ex
@@ -37,6 +37,7 @@ defmodule Arke.System do
         unit.data.parameters
       end
 
+      def is_arke?(), do: nil
       def on_load(data, _persistence_fn), do: {:ok, data}
       def before_load(data, _persistence_fn), do: {:ok, data}
       def on_validate(arke, unit), do: {:ok, unit}


### PR DESCRIPTION
## Description
naming convention follow Arke.System.Group that have `is_group?` function