### PR TITLE
feat: add nested filters and order

### DIFF
--- a/lib/arke/core/query.ex
+++ b/lib/arke/core/query.ex
@@ -347,7 +347,7 @@ defmodule Arke.Core.Query do
   def add_order(query, parameter, direction) do
     %{
       query
-      | orders: [%Order{parameter: parameter, direction: direction} | query.orders]
+      | orders: [%Order{parameter: parameter, direction: direction, path: []} | query.orders]
     }
   end
 

--- a/lib/arke/core/query.ex
+++ b/lib/arke/core/query.ex
@@ -51,11 +51,12 @@ defmodule Arke.Core.Query do
       - parameter => %Arke.Core.Parameter.`ParameterType` => refer to `Arke.Core.Parameter`
       - operator => refer to [operators](#module-operators)
       - value => any => the value that the query will search for
-      - negate => boolean => used to figure out whether the condition is to be denied \n
+      - negate => boolean => used to figure out whether the condition is to be denied
+      - path => [Arke.Core.Parameter.ParameterType] => the path of the parameter \n
       It is used to keep the same logic structure across all the Filter
     """
 
-    defstruct ~w[parameter operator value negate]a
+    defstruct ~w[parameter operator value negate path]a
     @type t() :: %Arke.Core.Query.BaseFilter{}
 
     @doc """
@@ -79,14 +80,16 @@ defmodule Arke.Core.Query do
             parameter :: Arke.Core.Parameter.ParameterType,
             operator :: atom(),
             value :: any,
-            negate :: boolean
+            negate :: boolean,
+            path :: [Arke.Core.Parameter.ParameterType]
           ) :: Arke.Core.Query.BaseFilter.t()
-    def new(parameter, operator, value, negate) do
+    def new(parameter, operator, value, negate, path) do
       %__MODULE__{
         parameter: parameter,
         operator: operator,
         value: cast_value(parameter, value),
-        negate: negate
+        negate: negate,
+        path: path
       }
     end
 
@@ -111,10 +114,11 @@ defmodule Arke.Core.Query do
     @moduledoc """
       Base struct Order:
       - parameter => %Arke.Core.Parameter.`ParameterType` => refer to `Arke.Core.Parameter`
-      - direction => "child" | "parent" => the direction the query will use to search \n
+      - direction => "child" | "parent" => the direction the query will use to search
+      - path => [Arke.Core.Parameter.ParameterType] => the path of the parameter \n
       It is used to define the return order of a Query
     """
-    defstruct ~w[parameter direction]a
+    defstruct ~w[parameter direction path]a
     @type t() :: %Arke.Core.Query.Order{}
   end
 
@@ -133,18 +137,19 @@ defmodule Arke.Core.Query do
       %Arke.Core.Query{}
 
   """
-  @spec new(arke :: %Arke.Core.Arke{}, project :: atom(), distinct :: atom()) :: Arke.Core.Query.t()
+  @spec new(arke :: %Arke.Core.Arke{}, project :: atom(), distinct :: atom()) ::
+          Arke.Core.Query.t()
   def new(arke, project, distinct \\ nil),
-      do: %__MODULE__{
-        project: project,
-        arke: arke,
-        distinct: distinct,
-        persistence: nil,
-        filters: [],
-        orders: [],
-        offset: nil,
-        limit: nil
-      }
+    do: %__MODULE__{
+      project: project,
+      arke: arke,
+      distinct: distinct,
+      persistence: nil,
+      filters: [],
+      orders: [],
+      offset: nil,
+      limit: nil
+    }
 
   @doc """
   Add a new link filter
@@ -303,8 +308,8 @@ defmodule Arke.Core.Query do
   # TODO: standardize parameter
   #  if it is a string convert it to existing atom and get it from paramater manager
   #  if it is an atom get it from paramater manaager
-  def new_base_filter(parameter, operator, value, negate) do
-    BaseFilter.new(parameter, operator, value, negate)
+  def new_base_filter(parameter, operator, value, negate, path \\ []) do
+    BaseFilter.new(parameter, operator, value, negate, path)
   end
 
   defp parse_base_filters(base_filters) when is_list(base_filters), do: base_filters
@@ -327,6 +332,16 @@ defmodule Arke.Core.Query do
   ## Return
       %Arke.Core.Query{ ... orders: [ %Arke.Core.Query.Order{} ] ... }
   """
+
+  def add_order(query, parameter, direction) when is_list(parameter) do
+    {parameter, path} = List.pop_at(parameter, -1)
+
+    %{
+      query
+      | orders: [%Order{parameter: parameter, direction: direction, path: path} | query.orders]
+    }
+  end
+
   def add_order(query, parameter, direction) do
     %{
       query

--- a/lib/arke/core/query.ex
+++ b/lib/arke/core/query.ex
@@ -221,8 +221,8 @@ defmodule Arke.Core.Query do
   ## Return
        %Arke.Core.Query{... filters: [ %Arke.Core.Query.Filter{} ] ... }
   """
-  def add_filter(query, parameter, operator, value, negate) do
-    %{query | filters: [new_filter(parameter, operator, value, negate) | query.filters]}
+  def add_filter(query, parameter, operator, value, negate, path \\ []) do
+    %{query | filters: [new_filter(parameter, operator, value, negate, path) | query.filters]}
   end
 
   @doc """
@@ -262,11 +262,11 @@ defmodule Arke.Core.Query do
   ## Return
       %Arke.Core.Query.Filter{base_filters: [ %Arke.Core.Query.BaseFilter{} ]}
   """
-  def new_filter(parameter, operator, value, negate) do
+  def new_filter(parameter, operator, value, negate, path \\ []) do
     %Filter{
       logic: :and,
       negate: false,
-      base_filters: [new_base_filter(parameter, operator, value, negate)]
+      base_filters: [new_base_filter(parameter, operator, value, negate, path)]
     }
   end
 
@@ -305,9 +305,11 @@ defmodule Arke.Core.Query do
       %Arke.Core.Query.BaseFilter{}
 
   """
+
   # TODO: standardize parameter
   #  if it is a string convert it to existing atom and get it from paramater manager
   #  if it is an atom get it from paramater manaager
+
   def new_base_filter(parameter, operator, value, negate, path \\ []) do
     BaseFilter.new(parameter, operator, value, negate, path)
   end

--- a/lib/arke/query_manager.ex
+++ b/lib/arke/query_manager.ex
@@ -409,7 +409,7 @@ defmodule Arke.QueryManager do
   defp parse_base_filters(query, filters) do
     Enum.reduce(filters, [], fn f, new_filters ->
       parameter = get_parameter(query, f.parameter)
-      [Query.new_base_filter(parameter, f.operator, f.value, f.negate) | new_filters]
+      [Query.new_base_filter(parameter, f.operator, f.value, f.negate, f.path) | new_filters]
     end)
   end
 
@@ -432,10 +432,11 @@ defmodule Arke.QueryManager do
           parameter :: Arke.t() | atom(),
           negate :: boolean(),
           value :: String.t() | boolean() | nil,
-          negate :: boolean()
+          negate :: boolean(),
+          path :: [Arke.t()]
         ) :: Query.BaseFilter.t()
-  def condition(parameter, operator, value, negate \\ false),
-    do: Query.new_base_filter(parameter, operator, value, negate)
+  def condition(parameter, operator, value, negate \\ false, path \\ []),
+    do: Query.new_base_filter(parameter, operator, value, negate, path)
 
   @doc """
   Create a list of `Arke.Core.Query.BaseFilter`
@@ -570,9 +571,19 @@ defmodule Arke.QueryManager do
   """
   @spec order(
           query :: Query.t(),
-          parameter :: Arke.t() | String.t() | atom(),
+          parameter :: Arke.t() | String.t() | atom() | [Arke.t()] | [String.t()] | [atom()],
           direction :: atom()
         ) :: Query.t()
+
+  def order(query, parameter, direction) when is_list(parameter) do
+    [head | tail] = parameter
+
+    parameters =
+      [get_parameter(query, head)] ++ Enum.map(tail, &get_parameter(%{query | arke: nil}, &1))
+
+    Query.add_order(query, parameters, direction)
+  end
+
   def order(query, parameter, direction),
     do: Query.add_order(query, get_parameter(query, parameter), direction)
 


### PR DESCRIPTION
## Description

You can now use nested filters within `QueryManager`

```ex
 QueryManager.query(project: "project") |> QueryManager.where(arke_id: :paperwork)|> QueryManager.filter("link_sales_point.business_name", :icontains, "p") |> QueryManager.count()
```

Nested filters are automatically parsed if called via api (see https://github.com/arkemishub/arke-server/pull/86)