### PR TITLE
feat: add keep_values_formatting for values of parameter

### DIFF
--- a/lib/arke/system.ex
+++ b/lib/arke/system.ex
@@ -543,11 +543,14 @@ defmodule Arke.System.BaseParameter do
   defp __check_map__(values), do: values
 
   defp __create_map_values__(values, opts, type, condition) do
+    keep = Keyword.get(opts, :keep_values_formatting, false)
     # FARE RAISE ECCEZIONE DA GESTIRE. CHIAVI DEVONO ESSERE TUTTE UGUALI
     with true <- Enum.all?(values, fn %{label: l, value: v} -> condition.(l, v) end) do
       new_values =
         Enum.map(values, fn k ->
-          %{label: String.capitalize(to_string(k.label)), value: __get_map_value__(k.value, type)}
+          label = to_string(k.label)
+          label = if keep, do: label, else: String.capitalize(label)
+          %{label: label, value: __get_map_value__(k.value, type)}
         end)
 
       __create_index__(opts, new_values)
@@ -560,10 +563,15 @@ defmodule Arke.System.BaseParameter do
   defp __get_map_value__(value, _), do: value
 
   defp __values_from_list__(values, opts, condition) do
+    keep = Keyword.get(opts, :keep_values_formatting, false)
     # FARE RAISE ECCEZIONE DA GESTIRE. CHIAVI DEVONO ESSERE TUTTE UGUALI
     with true <- Enum.all?(values, &condition.(&1)) do
       new_values =
-        Enum.map(values, fn k -> %{label: String.capitalize(to_string(k)), value: k} end)
+        Enum.map(values, fn k ->
+          label = to_string(k)
+          label = if keep, do: label, else: String.capitalize(label)
+          %{label: label, value: k}
+        end)
 
       __create_index__(opts, new_values)
     else


### PR DESCRIPTION
## Description
Parameters that define a fixed set of allowed values currently normalize each value's display label to sentence case, forcing the first letter to uppercase and the rest to lowercase. This is applied automatically, so labels like "iPhone", "USB-C" or "già pagato" are rewritten to "Iphone", "Usb-c" and "Già pagato", with no way to keep the label exactly as authored.

This PR introduces a new boolean option, `keep_values_formatting`, on parameters that support values. When enabled, the value labels are stored and returned exactly as provided, preserving the original casing and formatting.

Behavior

- keep_values_formatting: false (default): unchanged from today — value labels are normalized to sentence case. Existing parameters keep behaving exactly as before. (*NO REGRESSION*)
- keep_values_formatting: true: value labels are preserved verbatim, with no case transformation.

The option is fully backward compatible: parameters that don't set it fall back to the current default behavior.