### PR TITLE
fix: check_duplicate nil-guard clause was unreachable (arity mismatch)

### DIFF
--- a/lib/arke/validator.ex
+++ b/lib/arke/validator.ex
@@ -221,7 +221,7 @@ defmodule Arke.Validator do
 
   defp check_required_parameter(errors, _parameter, _value), do: errors
 
-  defp check_duplicate(errors, %{id: id, data: %{unique: true}} = _parameter, nil, project),
+  defp check_duplicate(errors, %{id: id, data: %{unique: true}} = _parameter, nil, _project, _arke),
        do: errors ++ [{"value must not be null for", id}]
 
   defp check_duplicate(errors, %{id: id, data: %{unique: true}} = parameter, value, project,arke) do

--- a/lib/arke/validator.ex
+++ b/lib/arke/validator.ex
@@ -221,7 +221,13 @@ defmodule Arke.Validator do
 
   defp check_required_parameter(errors, _parameter, _value), do: errors
 
-  defp check_duplicate(errors, %{id: id, data: %{unique: true}} = _parameter, nil, _project, _arke),
+  defp check_duplicate(
+         errors,
+         %{id: id, data: %{unique: true, required: true}} = _parameter,
+         nil,
+         _project,
+         _arke
+       ),
        do: errors ++ [{"value must not be null for", id}]
 
   defp check_duplicate(errors, %{id: id, data: %{unique: true}} = parameter, value, project,arke) do

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -472,16 +472,27 @@ defmodule Arke.ValidatorTest do
                {datetime, []}
     end
 
-    test "unique with nil value returns an error instead of passing silently" do
+    test "unique + required with nil value returns an error instead of passing silently" do
       # Regression test for the arity-4/arity-5 clause mismatch in
       # Validator.check_duplicate/4-5: the nil-guard clause was never
-      # reachable, so a `unique: true` parameter with a nil value skipped
-      # validation entirely instead of being rejected.
-      parameter = %{id: :username, data: %{unique: true}}
+      # reachable, so a `unique: true, required: true` parameter with a nil
+      # value skipped validation entirely instead of being rejected.
+      parameter = %{id: :username, data: %{unique: true, required: true}}
       arke = %{id: :test_arke}
 
       assert Arke.Validator.validate_parameter(arke, parameter, nil, :test_schema) ==
-               {nil, [{"value must not be null for", :username}]}
+               {nil,
+                [{:username, "is required"}, {"value must not be null for", :username}]}
+    end
+
+    test "unique + optional with nil value is allowed (unique-when-present)" do
+      # A unique field that isn't required must still accept nil — only
+      # required unique fields must reject it.
+      parameter = %{id: :nickname, data: %{unique: true, required: false}}
+      arke = %{id: :test_arke}
+
+      assert Arke.Validator.validate_parameter(arke, parameter, nil, :test_schema) ==
+               {nil, []}
     end
 
     test "unique" do

--- a/test/validator_test.exs
+++ b/test/validator_test.exs
@@ -472,6 +472,18 @@ defmodule Arke.ValidatorTest do
                {datetime, []}
     end
 
+    test "unique with nil value returns an error instead of passing silently" do
+      # Regression test for the arity-4/arity-5 clause mismatch in
+      # Validator.check_duplicate/4-5: the nil-guard clause was never
+      # reachable, so a `unique: true` parameter with a nil value skipped
+      # validation entirely instead of being rejected.
+      parameter = %{id: :username, data: %{unique: true}}
+      arke = %{id: :test_arke}
+
+      assert Arke.Validator.validate_parameter(arke, parameter, nil, :test_schema) ==
+               {nil, [{"value must not be null for", :username}]}
+    end
+
     test "unique" do
       arke = ArkeManager.get(:arke_test_support, :arke_system)
 


### PR DESCRIPTION
check_duplicate had a nil-value clause defined at arity 4, but every call site uses arity 5,
so it could never match. Confirmed via compiler warning ("function check_duplicate/4 is unused") when built in isolation.

Fixes #30.