### PR TITLE
chore: format pass and lint CI leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             otp: "26.2.5"
           - elixir: "1.18.4"
             otp: "26.2.5"
+            lint: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Elixir
@@ -43,6 +44,9 @@ jobs:
         run: mix deps.get
       - name: Compile dependencies
         run: mix deps.compile
+      - name: Ensure files are formatted
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
       - name: Build package
         run: mix hex.build
       - name: Run tests

--- a/lib/arke.ex
+++ b/lib/arke.ex
@@ -19,141 +19,171 @@ defmodule Arke do
 
   def init(), do: :ok
 
-  defp get_module(data,type) do
+  defp get_module(data, type) do
     # get all the arke modules which has the arke macro defined
     # find the right module for the given data and return it
-    arke_module_list = Enum.reduce(:application.loaded_applications(), [], fn {app, _, _}, arke_list ->
-      {:ok, modules} = :application.get_key(app, :modules)
+    arke_module_list =
+      Enum.reduce(:application.loaded_applications(), [], fn {app, _, _}, arke_list ->
+        {:ok, modules} = :application.get_key(app, :modules)
 
-      function_name = get_module_fn(type)
+        function_name = get_module_fn(type)
 
-      module_arke_list =
-        Enum.reduce(modules, [], fn mod, mod_arke_list ->
-          if Code.ensure_loaded?(mod) and :erlang.function_exported(mod, function_name, 0) and
-             apply(mod, function_name,[]) != nil do
-            [%{module: mod, arke_id: apply(mod, function_name,[]).id} | mod_arke_list]
-          else
-            mod_arke_list
-          end
-        end)
+        module_arke_list =
+          Enum.reduce(modules, [], fn mod, mod_arke_list ->
+            if Code.ensure_loaded?(mod) and :erlang.function_exported(mod, function_name, 0) and
+                 apply(mod, function_name, []) != nil do
+              [%{module: mod, arke_id: apply(mod, function_name, []).id} | mod_arke_list]
+            else
+              mod_arke_list
+            end
+          end)
 
+        arke_list ++ module_arke_list
+      end)
 
-      arke_list ++ module_arke_list
-    end)
-    Enum.find(arke_module_list,%{module: nil, arke_id: nil}, fn k ->
-    if is_map(k) do
-      to_string(k.arke_id) == to_string(Map.get(data,:id))
-                 end
+    Enum.find(arke_module_list, %{module: nil, arke_id: nil}, fn k ->
+      if is_map(k) do
+        to_string(k.arke_id) == to_string(Map.get(data, :id))
+      end
     end)[:module]
   end
+
   defp get_module_fn("arke"), do: :arke_from_attr
   defp get_module_fn("group"), do: :group_from_attr
 
-  def handle_manager(_data,_project,_arke_id,_error\\[])
-  def handle_manager([data | t],project,:parameter,error)do
-    {type, updated_data} = Map.pop(data,:type)
+  def handle_manager(_data, _project, _arke_id, _error \\ [])
+
+  def handle_manager([data | t], project, :parameter, error) do
+    {type, updated_data} = Map.pop(data, :type)
     final_data = BaseParameter.check_enum(type, updated_data) |> Enum.into(%{})
-    updated_error = start_manager(final_data,type,project,ParameterManager,nil)
-    handle_manager(t,project, :parameter,updated_error ++ error)
+    updated_error = start_manager(final_data, type, project, ParameterManager, nil)
+    handle_manager(t, project, :parameter, updated_error ++ error)
   end
 
-  def handle_manager([data | t],project,:arke,error) do
-    {flatten_data,other} = Map.pop(data,:data,%{})
-    updated_data = Map.merge(flatten_data,other)
-                   |> Map.put(:type,Map.get(data,:type,"arke"))
-                   |> Map.put_new(:active,true)
+  def handle_manager([data | t], project, :arke, error) do
+    {flatten_data, other} = Map.pop(data, :data, %{})
 
-    final_data = Map.replace(updated_data,:parameters,parse_arke_parameter(updated_data,project))
-    module = get_module(final_data,"arke")
-    updated_error = start_manager(final_data,"arke",project,ArkeManager, module)
-    handle_manager(t,project, :arke,updated_error ++ error)
+    updated_data =
+      Map.merge(flatten_data, other)
+      |> Map.put(:type, Map.get(data, :type, "arke"))
+      |> Map.put_new(:active, true)
+
+    final_data =
+      Map.replace(updated_data, :parameters, parse_arke_parameter(updated_data, project))
+
+    module = get_module(final_data, "arke")
+    updated_error = start_manager(final_data, "arke", project, ArkeManager, module)
+    handle_manager(t, project, :arke, updated_error ++ error)
   end
 
-  def handle_manager([data | t],project,:group,error)do
-    loaded_list = Enum.reduce(Map.get(data,:arke_list,[]),[], fn arke,acc ->
-      with %{id: id, metadata: _metadata}=link_data <- parse_group_member(arke),
-           %Unit{}= _arke_unit <- ArkeManager.get(id, project) do
+  def handle_manager([data | t], project, :group, error) do
+    loaded_list =
+      Enum.reduce(Map.get(data, :arke_list, []), [], fn arke, acc ->
+        with %{id: id, metadata: _metadata} = link_data <- parse_group_member(arke),
+             %Unit{} = _arke_unit <- ArkeManager.get(id, project) do
           [link_data | acc]
         else
           _ ->
-            [%{context: :arke_list_group , message: "invalid arke in arke_list of: `#{data.id}` in `#{project}`"} | error]
-      end
+            [
+              %{
+                context: :arke_list_group,
+                message: "invalid arke in arke_list of: `#{data.id}` in `#{project}`"
+              }
+              | error
+            ]
+        end
+      end)
 
-    end)
+    final_data = Map.put(data, :arke_list, loaded_list)
+    module = get_module(final_data, "group")
+    updated_error = start_manager(final_data, "group", project, GroupManager, module)
 
-    final_data=  Map.put(data,:arke_list,loaded_list)
-    module = get_module(final_data,"group")
-    updated_error = start_manager(final_data,"group",project,GroupManager,module)
-
-    handle_manager(t,project, :group,updated_error ++ error)
+    handle_manager(t, project, :group, updated_error ++ error)
   end
 
-  def handle_manager([],_project,_arke_id,error),do: error
+  def handle_manager([], _project, _arke_id, error), do: error
 
-  defp parse_group_member(member) when is_binary(member), do: %{id: String.to_atom(member), metadata: %{}}
+  defp parse_group_member(member) when is_binary(member),
+    do: %{id: String.to_atom(member), metadata: %{}}
+
   defp parse_group_member(member) when is_map(member) do
-    case Map.get(member,:id) do
-    nil -> {:error,"arke id not found"}
-    id -> %{id: id, metadata: Map.get(member, :metadata, %{})}
+    case Map.get(member, :id) do
+      nil -> {:error, "arke id not found"}
+      id -> %{id: id, metadata: Map.get(member, :metadata, %{})}
     end
- end
-
-  defp start_manager(_data,_type,_project, _manager, _module,_error\\[])
-
-  defp start_manager(data,type,project, manager, module,error) do
-    case Map.pop(data,:id,nil) do
-      {nil, _updated_data} -> [%{context: :manager , message: "key id not found"} | error]
-      {id, updated_data} ->
-        {metadata,updated_data} = Map.pop(updated_data,:metadata,%{project: project})
-        case manager.create(
-                                    Unit.new(
-                                      String.to_atom(id),
-                                      updated_data,
-                                      String.to_atom(type),
-                                      nil,
-                                      metadata,
-                                      nil,
-                                      nil,
-                                      module
-                                    ),
-                                    project
-                                  ) do
-                               %Unit{} = _unit ->
-                                 error
-                               _ ->[%{context: :manager , message: "cannot start manager for: `#{id}`"} | error]
-                             end
-    end
-
   end
-  defp parse_arke_parameter(data,project) do
-    base_parameters(Map.get(data,:parameters,[]), Map.get(data,:type,"arke")) |> Enum.reduce([], fn param,acc ->
+
+  defp start_manager(_data, _type, _project, _manager, _module, _error \\ [])
+
+  defp start_manager(data, type, project, manager, module, error) do
+    case Map.pop(data, :id, nil) do
+      {nil, _updated_data} ->
+        [%{context: :manager, message: "key id not found"} | error]
+
+      {id, updated_data} ->
+        {metadata, updated_data} = Map.pop(updated_data, :metadata, %{project: project})
+
+        case manager.create(
+               Unit.new(
+                 String.to_atom(id),
+                 updated_data,
+                 String.to_atom(type),
+                 nil,
+                 metadata,
+                 nil,
+                 nil,
+                 module
+               ),
+               project
+             ) do
+          %Unit{} = _unit ->
+            error
+
+          _ ->
+            [%{context: :manager, message: "cannot start manager for: `#{id}`"} | error]
+        end
+    end
+  end
+
+  defp parse_arke_parameter(data, project) do
+    base_parameters(Map.get(data, :parameters, []), Map.get(data, :type, "arke"))
+    |> Enum.reduce([], fn param, acc ->
       # controllare anche che il parameter manager torni qualcosa che esiste
-      converted = Map.update(param,:id, "tbd", &String.to_atom(to_string(&1)))
+      converted = Map.update(param, :id, "tbd", &String.to_atom(to_string(&1)))
       id = converted[:id]
 
-
-      case ParameterManager.get(id,project) do
+      case ParameterManager.get(id, project) do
         %Unit{} = arke ->
-        type = arke.arke_id
-          final_data = Map.update(converted,:metadata,%{}, &(
-            BaseParameter.check_enum(type, &1) |>
-              Enum.into(%{}))
-          )
-          |> Map.put(:arke, type)
-          [ final_data | acc]
-        _ -> acc
+          type = arke.arke_id
+
+          final_data =
+            Map.update(
+              converted,
+              :metadata,
+              %{},
+              &(BaseParameter.check_enum(type, &1)
+                |> Enum.into(%{}))
+            )
+            |> Map.put(:arke, type)
+
+          [final_data | acc]
+
+        _ ->
+          acc
       end
     end)
   end
 
-  defp base_parameters(arke_parameters,"arke") do
-    arke_parameters ++ [
-      %{id: "id", metadata: %{required: true, persistence: "table_column"}},
-      %{id: "arke_id", metadata: %{required: false, persistence: "table_column"}},
-      %{id: "metadata", metadata: %{required: false, persistence: "table_column"}},
-      %{id: "inserted_at", metadata: %{required: false, persistence: "table_column"}},
-      %{id: "updated_at", metadata: %{required: false, persistence: "table_column"}}]
+  defp base_parameters(arke_parameters, "arke") do
+    arke_parameters ++
+      [
+        %{id: "id", metadata: %{required: true, persistence: "table_column"}},
+        %{id: "arke_id", metadata: %{required: false, persistence: "table_column"}},
+        %{id: "metadata", metadata: %{required: false, persistence: "table_column"}},
+        %{id: "inserted_at", metadata: %{required: false, persistence: "table_column"}},
+        %{id: "updated_at", metadata: %{required: false, persistence: "table_column"}}
+      ]
   end
+
   defp base_parameters(arke_parameters, _type), do: arke_parameters
 end
-

--- a/lib/arke/application.ex
+++ b/lib/arke/application.ex
@@ -20,13 +20,14 @@ defmodule Arke.Application do
   use Application
   @impl true
   def start(_type, _args) do
-    topologies = Application.get_env(:libcluster, :topologies,[])
+    topologies = Application.get_env(:libcluster, :topologies, [])
+
     children = [
       {Arke.Boundary.ParameterManager, [name: Arke.Boundary.ParameterManager]},
       {Arke.Boundary.ArkeManager, [name: Arke.Boundary.ArkeManager]},
       {Arke.Boundary.GroupManager, [name: Arke.Boundary.GroupManager]},
       {Arke.Boundary.FileManager, [name: Arke.Boundary.FileManager]},
-      {Cluster.Supervisor, [topologies, [name: Arke.ClusterSupervisor]]},
+      {Cluster.Supervisor, [topologies, [name: Arke.ClusterSupervisor]]}
       # Starts a worker by calling: ArkeMonorepo.Worker.start_link(arg)
       # {ArkeMonorepo.Worker, arg}
     ]

--- a/lib/arke/boundary/arke_manager.ex
+++ b/lib/arke/boundary/arke_manager.ex
@@ -14,8 +14,8 @@
 
 defmodule Arke.Boundary.ArkeManager do
   @moduledoc """
-             This module manage the gen servers for the element specified in `Arke.Core.Arke`
-             """
+  This module manage the gen servers for the element specified in `Arke.Core.Arke`
+  """
 
   alias Arke.Utils.ErrorGenerator, as: Error
   use Arke.Boundary.UnitManager
@@ -35,7 +35,6 @@ defmodule Arke.Boundary.ArkeManager do
                                           metadata: parameter_metadata
                                         },
                                         new_parameters ->
-
       case init_parameter(project, parameter_id, parameter_metadata) do
         {:error, msg} -> new_parameters
         parameter -> [parameter | new_parameters]
@@ -65,7 +64,6 @@ defmodule Arke.Boundary.ArkeManager do
              %Unit{} = parameter <- init_parameter(project, id, metadata),
              do: parameter,
              else: ({:error, msg} -> nil)
-
     end
   end
 
@@ -93,12 +91,10 @@ defmodule Arke.Boundary.ArkeManager do
     end
   end
 
-
   defp check_module(%{__module__: nil} = unit),
     do: Unit.update(unit, __module__: Arke.System.Arke)
 
   defp check_module(unit), do: unit
-
 
   defp init_parameter(project, id, metadata, p) do
     arke_id = Map.get(p, :arke, nil)
@@ -115,7 +111,6 @@ defmodule Arke.Boundary.ArkeManager do
       nil,
       nil
     )
-
   end
 
   defp init_parameter(project, id, metadata) do
@@ -136,6 +131,8 @@ defmodule Arke.Boundary.ArkeManager do
   end
 
   defp handle_init_p(id, parameter, override_data) do
-    Map.update(parameter,:data, %{},fn v -> Map.merge(v,override_data, fn _k, pdata,ovdata -> ovdata end) end)
+    Map.update(parameter, :data, %{}, fn v ->
+      Map.merge(v, override_data, fn _k, pdata, ovdata -> ovdata end)
+    end)
   end
 end

--- a/lib/arke/boundary/group_manager.ex
+++ b/lib/arke/boundary/group_manager.ex
@@ -20,7 +20,7 @@ defmodule Arke.Boundary.GroupManager do
   manager_id(:group)
 
   defp check_module(%{__module__: nil} = unit),
-       do: Unit.update(unit, __module__: Arke.System.BaseGroup)
+    do: Unit.update(unit, __module__: Arke.System.BaseGroup)
 
   defp check_module(unit), do: unit
 
@@ -59,11 +59,11 @@ defmodule Arke.Boundary.GroupManager do
 
       unit ->
         with %Unit{} = arke <-
-          Enum.find(get_arke_list(unit), {:error, "arke id not found"}, fn f ->
-            f.id == arke_id
-          end),
-        do: arke,
-        else: ({:error, msg} -> nil)
+               Enum.find(get_arke_list(unit), {:error, "arke id not found"}, fn f ->
+                 f.id == arke_id
+               end),
+             do: arke,
+             else: ({:error, msg} -> nil)
     end
   end
 
@@ -77,22 +77,23 @@ defmodule Arke.Boundary.GroupManager do
 
     Enum.reduce(group_keys, [], fn {g, _}, groups ->
       group = get(g, project)
+
       if arke_id in Enum.map(group.data.arke_list, fn a -> a.id end) do
-      [group | groups]
+        [group | groups]
       else
-      groups
+        groups
       end
     end)
   end
 
   def get_parameters(group_id, project), do: get(group_id, project) |> get_parameters
+
   def get_parameters(%{id: id, metadata: %{project: project}} = group) do
     parameters =
       get_arke_list(group)
       |> get_group_parameters(project)
       |> init_parameters_by_ids(project)
   end
-
 
   defp get_group_parameters(arke_list, _project) do
     Enum.reduce(arke_list, [], fn arke, group_parameters ->

--- a/lib/arke/boundary/group_manager.ex
+++ b/lib/arke/boundary/group_manager.ex
@@ -112,7 +112,7 @@ defmodule Arke.Boundary.GroupManager do
 
   defp check_group_parameters(group_parameters, arke_parameters) do
     arke_ids = Enum.map(arke_parameters, fn p -> p.id end)
-    group_parameters -- group_parameters -- arke_ids
+    group_parameters -- (group_parameters -- arke_ids)
   end
 
   defp link_init(project, :arke_list, child_id, metadata) do

--- a/lib/arke/boundary/parameter_manager.ex
+++ b/lib/arke/boundary/parameter_manager.ex
@@ -19,6 +19,4 @@ defmodule Arke.Boundary.ParameterManager do
   manager_id(:parameter)
   # set_registry_name(:parameter_registry)
   # set_supervisor_name(:parameter_supervisor)
-
-  
 end

--- a/lib/arke/boundary/unit_manager.ex
+++ b/lib/arke/boundary/unit_manager.ex
@@ -101,7 +101,7 @@ defmodule Arke.Boundary.UnitManager do
         {manager, opts} = Keyword.pop(opts, :manager, __MODULE__)
         {unit, project} = before_create(unit, project)
         current_node_create = GenServer.call(manager, {:create, unit, project})
-        call_nodes_manager(manager,:create,[unit,project])
+        call_nodes_manager(manager, :create, [unit, project])
         current_node_create
       end
 
@@ -113,7 +113,7 @@ defmodule Arke.Boundary.UnitManager do
       def update(unit_id, project, new_unit) do
         unit = get(unit_id, project)
         current_node_update = GenServer.call(__MODULE__, {:update, new_unit, project})
-        call_nodes_manager(__MODULE__,:update,[new_unit,project])
+        call_nodes_manager(__MODULE__, :update, [new_unit, project])
         current_node_update
       end
 
@@ -126,9 +126,8 @@ defmodule Arke.Boundary.UnitManager do
       defp exec_call_func(unit, func, opts) when is_nil(unit),
         do: get(:arke, :arke_system) |> exec_call_func(func, opts)
 
-      defp exec_call_func(%{__module__: module} = unit, func, opts) when is_nil(module), do:
-           {:error, "No Module"}
-
+      defp exec_call_func(%{__module__: module} = unit, func, opts) when is_nil(module),
+        do: {:error, "No Module"}
 
       defp exec_call_func(
              %{id: id, metadata: %{project: project}, __module__: module} = unit,
@@ -171,10 +170,14 @@ defmodule Arke.Boundary.UnitManager do
         manager = __MODULE__
 
         case get(unit_id, project) do
-          nil -> {:error, "#{unit_id} doesn't exist in project: #{project}"}
+          nil ->
+            {:error, "#{unit_id} doesn't exist in project: #{project}"}
+
           unit ->
-            current_node_update = GenServer.call(manager, {:add_link, unit, parameter_id, child_id, metadata})
-            call_nodes_manager(manager,:add_link,[unit, parameter_id, child_id, metadata])
+            current_node_update =
+              GenServer.call(manager, {:add_link, unit, parameter_id, child_id, metadata})
+
+            call_nodes_manager(manager, :add_link, [unit, parameter_id, child_id, metadata])
             current_node_update
         end
       end
@@ -188,10 +191,14 @@ defmodule Arke.Boundary.UnitManager do
         manager = __MODULE__
 
         case get(unit_id, project) do
-          nil -> {:error, "#{unit_id} doesn't exist in project: #{project}"}
+          nil ->
+            {:error, "#{unit_id} doesn't exist in project: #{project}"}
+
           unit ->
-            current_node_update = GenServer.call(manager, {:remove_link, unit, parameter_id, child_id})
-            call_nodes_manager(manager,:remove_link,[unit, parameter_id, child_id])
+            current_node_update =
+              GenServer.call(manager, {:remove_link, unit, parameter_id, child_id})
+
+            call_nodes_manager(manager, :remove_link, [unit, parameter_id, child_id])
             current_node_update
         end
       end
@@ -238,16 +245,19 @@ defmodule Arke.Boundary.UnitManager do
         do: %{id: child_id, metadata: metadata}
 
       # Update all nodes manager
-      defp call_nodes_manager(manager,func_name,opts) do
-        tuple_data = Enum.reduce(opts,{func_name},fn opt,acc -> Tuple.append(acc,opt) end)
-        {right_nodes, bad_nodes} = :rpc.multicall(Node.list(),GenServer,:call,[manager, tuple_data])
-        if length(bad_nodes)>0 do
+      defp call_nodes_manager(manager, func_name, opts) do
+        tuple_data = Enum.reduce(opts, {func_name}, fn opt, acc -> Tuple.append(acc, opt) end)
+
+        {right_nodes, bad_nodes} =
+          :rpc.multicall(Node.list(), GenServer, :call, [manager, tuple_data])
+
+        if length(bad_nodes) > 0 do
           Enum.each(bad_nodes, fn unit ->
             Logger.warning("Something went wrong during multi node update for unit: `#{unit.id}`")
           end)
-
         end
-        {right_nodes,bad_nodes}
+
+        {right_nodes, bad_nodes}
       end
 
       # Remove link

--- a/lib/arke/core/parameter.ex
+++ b/lib/arke/core/parameter.ex
@@ -43,7 +43,6 @@ defmodule Arke.Core.Parameter do
   """
   alias Arke.Boundary.ParameterManager
 
-
   @type parameter_struct() ::
           Parameter.Boolean.t()
           | Parameter.String.t()
@@ -52,8 +51,8 @@ defmodule Arke.Core.Parameter do
           | Parameter.Float.t()
 
   @doc """
-       Macro defining a shared struct of parameter used across Arkes
-       """
+  Macro defining a shared struct of parameter used across Arkes
+  """
   use Arke.System.Group
 
   group id: "parameter" do
@@ -73,7 +72,6 @@ defmodule Arke.Core.Parameter do
     ParameterManager.remove(unit)
     {:ok, unit}
   end
-
 end
 
 defmodule Arke.Core.Parameter.String do
@@ -98,7 +96,7 @@ defmodule Arke.Core.Parameter.String do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "string" do
@@ -108,7 +106,6 @@ defmodule Arke.Core.Parameter.String do
     args = Arke.System.BaseParameter.check_enum(:string, Map.to_list(data))
     {:ok, Enum.into(args, %{})}
   end
-
 end
 
 defmodule Arke.Core.Parameter.Integer do
@@ -132,7 +129,7 @@ defmodule Arke.Core.Parameter.Integer do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "integer" do
@@ -142,7 +139,6 @@ defmodule Arke.Core.Parameter.Integer do
     args = Arke.System.BaseParameter.check_enum(:integer, Map.to_list(data))
     {:ok, Enum.into(args, %{})}
   end
-
 end
 
 defmodule Arke.Core.Parameter.Float do
@@ -166,7 +162,7 @@ defmodule Arke.Core.Parameter.Float do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "float" do
@@ -176,7 +172,6 @@ defmodule Arke.Core.Parameter.Float do
     args = Arke.System.BaseParameter.check_enum(:float, Map.to_list(data))
     {:ok, Enum.into(args, %{})}
   end
-
 end
 
 defmodule Arke.Core.Parameter.Boolean do
@@ -196,10 +191,10 @@ defmodule Arke.Core.Parameter.Boolean do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
-  arke id: "boolean"  do
+  arke id: "boolean" do
   end
 end
 
@@ -220,7 +215,7 @@ defmodule Arke.Core.Parameter.Dict do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "dict" do
@@ -244,7 +239,7 @@ defmodule Arke.Core.Parameter.List do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "list" do
@@ -276,7 +271,7 @@ defmodule Arke.Core.Parameter.Date do
 
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "date" do
@@ -307,12 +302,11 @@ defmodule Arke.Core.Parameter.Time do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "time" do
   end
-
 end
 
 defmodule Arke.Core.Parameter.DateTime do
@@ -342,7 +336,7 @@ defmodule Arke.Core.Parameter.DateTime do
 
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "datetime" do
@@ -366,12 +360,11 @@ defmodule Arke.Core.Parameter.Link do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
-  arke  id: "link" do
+  arke id: "link" do
   end
-
 end
 
 defmodule Arke.Core.Parameter.Dynamic do
@@ -384,7 +377,7 @@ defmodule Arke.Core.Parameter.Dynamic do
   """
   alias Arke.Core.Parameter
   alias Arke.Boundary.ParameterManager
-  
+
   use Arke.System
 
   arke id: "dynamic" do
@@ -405,5 +398,4 @@ defmodule Arke.Core.Parameter.Binary do
 
   arke id: "binary" do
   end
-
 end

--- a/lib/arke/core/project.ex
+++ b/lib/arke/core/project.ex
@@ -22,7 +22,8 @@ defmodule Arke.Core.Project do
 
   @persistence Application.get_env(:arke, :persistence)
 
-  arke id: :arke_project do  end
+  arke id: :arke_project do
+  end
 
   def on_create(_, unit) do
     persistence_fn = @persistence[:arke_postgres][:create_project]

--- a/lib/arke/core/query.ex
+++ b/lib/arke/core/query.ex
@@ -100,13 +100,26 @@ defmodule Arke.Core.Query do
 
     defp cast_value(%Arke.Core.Unit{arke_id: arke_id} = _parameter, value) do
       case arke_id do
-        :datetime -> cast_temporal(&Arke.Utils.DatetimeHandler.parse_datetime/1, value, "datetime")
-        :date -> cast_temporal(&Arke.Utils.DatetimeHandler.parse_date/1, value, "date")
-        :time -> cast_temporal(&Arke.Utils.DatetimeHandler.parse_time/1, value, "time")
-        :integer -> cast_integer(value)
-        :float -> cast_float(value)
-        :boolean -> cast_boolean(value)
-        _ -> value
+        :datetime ->
+          cast_temporal(&Arke.Utils.DatetimeHandler.parse_datetime/1, value, "datetime")
+
+        :date ->
+          cast_temporal(&Arke.Utils.DatetimeHandler.parse_date/1, value, "date")
+
+        :time ->
+          cast_temporal(&Arke.Utils.DatetimeHandler.parse_time/1, value, "time")
+
+        :integer ->
+          cast_integer(value)
+
+        :float ->
+          cast_float(value)
+
+        :boolean ->
+          cast_boolean(value)
+
+        _ ->
+          value
       end
     end
 

--- a/lib/arke/core/unit.ex
+++ b/lib/arke/core/unit.ex
@@ -268,7 +268,6 @@ defmodule Arke.Core.Unit do
 
   defp update_encoded_unit_data(_, data, _), do: data
 
-
   defp handle_id(id) when is_nil(id), do: UUID.uuid1()
   defp handle_id(id) when is_atom(id), do: Atom.to_string(id)
   defp handle_id(id) when is_binary(id), do: id

--- a/lib/arke/group.ex
+++ b/lib/arke/group.ex
@@ -26,8 +26,11 @@ defmodule Arke.System.Group do
 
       #      @before_compile unquote(__MODULE__)
 
-      def group_from_attr(), do: Keyword.get(__MODULE__.__info__(:attributes), :group, []) |> List.first()
-      def is_group?(), do: Keyword.get(__MODULE__.__info__(:attributes), :system_group, []) |> List.first()
+      def group_from_attr(),
+        do: Keyword.get(__MODULE__.__info__(:attributes), :group, []) |> List.first()
+
+      def is_group?(),
+        do: Keyword.get(__MODULE__.__info__(:attributes), :system_group, []) |> List.first()
 
       def on_unit_load(arke, data, _persistence_fn), do: {:ok, data}
       def before_unit_load(_arke, data, _persistence_fn), do: {:ok, data}
@@ -96,7 +99,7 @@ defmodule Arke.System.Group do
       unquote(block)
 
       @group %{
-        id: id,
+        id: id
       }
     end
   end
@@ -114,7 +117,7 @@ defmodule Arke.System.Group do
   See example above `arke/2`
 
   """
-  @spec parameter(id :: atom(), type:: atom(), opts :: list()) :: Macro.t()
+  @spec parameter(id :: atom(), type :: atom(), opts :: list()) :: Macro.t()
   defmacro parameter(id, type, opts \\ []) do
     # parameter_dict = Arke.System.BaseParameter.parameter_options(opts, id, type)
     quote bind_quoted: [id: id, type: type, opts: opts] do

--- a/lib/arke/link_manager.ex
+++ b/lib/arke/link_manager.ex
@@ -24,7 +24,6 @@ defmodule Arke.LinkManager do
   def add_node(project, %Unit{} = parent, %Unit{} = child, type \\ "link", metadata \\ %{}) do
     arke_link = ArkeManager.get(:arke_link, project)
 
-
     case check_link(project, parent, child, type, arke_link) do
       {_, nil} ->
         QueryManager.create(project, arke_link,
@@ -41,15 +40,16 @@ defmodule Arke.LinkManager do
 
   def add_node(project, parent, child, type, metadata)
       when is_binary(parent) and is_binary(child) do
-    with %Unit{}=unit_parent <- QueryManager.get_by(id: parent, project: project),
-         %Unit{}=unit_child <- QueryManager.get_by(id: child, project: project) do
+    with %Unit{} = unit_parent <- QueryManager.get_by(id: parent, project: project),
+         %Unit{} = unit_child <- QueryManager.get_by(id: child, project: project) do
       add_node(project, unit_parent, unit_child, type, metadata)
-      else
-      _ ->  Error.create(:link, "parent: `#{parent}` or child: `#{child}` not found")
+    else
+      _ -> Error.create(:link, "parent: `#{parent}` or child: `#{child}` not found")
     end
   end
 
-  def add_node(_project,  _parent, _child, _type, _metadata), do: Error.create(:link, "invalid parameters")
+  def add_node(_project, _parent, _child, _type, _metadata),
+    do: Error.create(:link, "invalid parameters")
 
   def update_node(project, %Unit{} = parent, %Unit{} = child, type, metadata) do
     arke_link = ArkeManager.get(:arke_link, :arke_system)

--- a/lib/arke/utils/datetime_handler.ex
+++ b/lib/arke/utils/datetime_handler.ex
@@ -215,7 +215,9 @@ defmodule Arke.Utils.DatetimeHandler do
 
   defp shift_days(value, 0), do: value
   defp shift_days(%Date{} = date, days), do: Date.add(date, days)
-  defp shift_days(%DateTime{} = datetime, days), do: replace_date(datetime, Date.add(datetime, days))
+
+  defp shift_days(%DateTime{} = datetime, days),
+    do: replace_date(datetime, Date.add(datetime, days))
 
   defp shift_years(value, 0), do: value
 

--- a/lib/arke/utils/default_data.ex
+++ b/lib/arke/utils/default_data.ex
@@ -1,5 +1,20 @@
 defmodule Arke.Utils.DefaultData do
-
   def get_arke_id(), do: get_parameters_id() ++ ["arke", "group"]
-  def get_parameters_id(), do:  ["boolean","binary","dict","list","float","integer","string","unit","link","dynamic","date","datetime","time"]
+
+  def get_parameters_id(),
+    do: [
+      "boolean",
+      "binary",
+      "dict",
+      "list",
+      "float",
+      "integer",
+      "string",
+      "unit",
+      "link",
+      "dynamic",
+      "date",
+      "datetime",
+      "time"
+    ]
 end

--- a/lib/arke/utils/error_generator.ex
+++ b/lib/arke/utils/error_generator.ex
@@ -50,6 +50,7 @@ defmodule Arke.Utils.ErrorGenerator do
   def create(_context, _errors), do: create(:error_generator, "invalid attribute format")
 
   defp create_map(_context, _errors, error_list \\ [])
+
   defp create_map(context, [{message, values} = _h | t] = _errors, error_list)
        when is_list(values) do
     create_map(

--- a/lib/arke/utils/file_storage.ex
+++ b/lib/arke/utils/file_storage.ex
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 defmodule Arke.Utils.FileStorage do
-
-  defmacro __using__(_)do
+  defmacro __using__(_) do
     quote do
-
       def upload_file(file_name, file_data, opts \\ []), do: {:ok, nil}
 
       def get_file(file_path, opts \\ []), do: nil
@@ -34,5 +32,4 @@ defmodule Arke.Utils.FileStorage do
                      get_bucket_file_signed_url: 2
     end
   end
-
 end

--- a/lib/arke/utils/gcp.ex
+++ b/lib/arke/utils/gcp.ex
@@ -53,7 +53,9 @@ defmodule Arke.Utils.Gcp do
 
   def get_public_url(%{data: %{name: name, path: path, extension: ext}} = unit, opts \\ []) do
     bucket = opts[:bucket] || System.get_env("DEFAULT_BUCKET")
-    {:ok, %{signed_url: "https://storage.googleapis.com/#{bucket}/#{path}/#{name}",expiration: nil}}
+
+    {:ok,
+     %{signed_url: "https://storage.googleapis.com/#{bucket}/#{path}/#{name}", expiration: nil}}
   end
 
   def get_public_url(_unit, _opts), do: Error.create(:storage, "invalid unit")
@@ -71,7 +73,9 @@ defmodule Arke.Utils.Gcp do
   """
   def get_bucket_file_signed_url(file_path, opts \\ []) do
     if opts[:service_account] do
-      Logger.warning("service_account option is ignored: urls are signed as the credentials' client_email")
+      Logger.warning(
+        "service_account option is ignored: urls are signed as the credentials' client_email"
+      )
     end
 
     expires = DateTime.utc_now() |> DateTime.to_unix() |> Kernel.+(1 * 3600)

--- a/lib/arke/validator.ex
+++ b/lib/arke/validator.ex
@@ -43,7 +43,7 @@ defmodule Arke.Validator do
       %{:error, [message]}
 
   """
-  @spec validate(unit :: Unit.t(), peristence_fn :: (() -> any()), project :: atom()) ::
+  @spec validate(unit :: Unit.t(), peristence_fn :: (-> any()), project :: atom()) ::
           func_return()
   def validate(%{arke_id: arke_id} = unit, persistence_fn, project \\ :arke_system) do
     with {:ok, unit} <- check_duplicate_unit(unit, project, persistence_fn) do
@@ -54,6 +54,7 @@ defmodule Arke.Validator do
         Enum.filter(ArkeManager.get_parameters(arke), fn %{data: %{persistence: persistence}} ->
           persistence == "arke_parameter"
         end)
+
       res =
         Enum.reduce(unit_parameters, {unit, errors}, fn p, {new_unit, errors} = _res ->
           {value, err} = validate_parameter(arke, p, Unit.get_value(data, p.id), project)
@@ -135,7 +136,7 @@ defmodule Arke.Validator do
 
   def validate_parameter(arke, parameter, value, project) when is_atom(parameter) do
     parameter = get_parameter(arke, parameter, project)
-    check_parameter(parameter, value, project,arke)
+    check_parameter(parameter, value, project, arke)
   end
 
   defp get_parameter(nil, parameter_id, project),
@@ -145,20 +146,20 @@ defmodule Arke.Validator do
     do: ArkeManager.get_parameter(arke, parameter_id)
 
   def validate_parameter(arke, parameter, value, project) do
-    check_parameter(parameter, value, project,arke)
+    check_parameter(parameter, value, project, arke)
   end
 
-  defp check_parameter(parameter, value, project,arke) do
+  defp check_parameter(parameter, value, project, arke) do
     value = get_default_value(parameter, value)
     value = parse_value(parameter, value)
     value = check_whitespace(parameter, value)
-    value = check_lowercase(parameter,value)
+    value = check_lowercase(parameter, value)
 
     errors =
       []
       |> check_required_parameter(parameter, value)
       |> check_by_type(parameter, value)
-      |> check_duplicate(parameter, value, project,arke)
+      |> check_duplicate(parameter, value, project, arke)
 
     {value, errors}
   end
@@ -222,15 +223,15 @@ defmodule Arke.Validator do
   defp check_required_parameter(errors, _parameter, _value), do: errors
 
   defp check_duplicate(errors, %{id: id, data: %{unique: true}} = _parameter, nil, project),
-       do: errors ++ [{"value must not be null for", id}]
+    do: errors ++ [{"value must not be null for", id}]
 
-  defp check_duplicate(errors, %{id: id, data: %{unique: true}} = parameter, value, project,arke) do
+  defp check_duplicate(errors, %{id: id, data: %{unique: true}} = parameter, value, project, arke) do
     with nil <- QueryManager.get_by(%{id => value, :project => project, :arke_id => arke.id}),
          do: errors,
          else: (_ -> errors ++ [{"duplicate values are not allowed for", id}])
   end
 
-  defp check_duplicate(errors, _parameter, _value, _project,_arke), do: errors
+  defp check_duplicate(errors, _parameter, _value, _project, _arke), do: errors
 
   defp check_by_type(errors, _parameter, value) when is_nil(value), do: errors
 
@@ -259,11 +260,12 @@ defmodule Arke.Validator do
 
   defp check_values(
          errors,
-         %{arke_id: type, data: %{values: values, label: label,multiple: true}} = parameter,
+         %{arke_id: type, data: %{values: values, label: label, multiple: true}} = parameter,
          value
        )
        when is_list(value) do
     admitted_values = Enum.map(values, fn %{label: _l, value: v} -> v end)
+
     with true <- check_values_type(value, type) do
       with [] <- value -- admitted_values do
         errors
@@ -288,7 +290,8 @@ defmodule Arke.Validator do
          value
        ),
        do: errors ++ [{value, "#{label} must be a list of #{type}}"}]
- defp check_values(errors,_parameter,_value), do: errors
+
+  defp check_values(errors, _parameter, _value), do: errors
 
   defp check_values_type(value, type) do
     condition =
@@ -300,18 +303,32 @@ defmodule Arke.Validator do
 
     Enum.all?(value, &condition.(&1))
   end
+
   # --- end Enum ---
   # --- start Multiple ---
-  defp check_multiple(errors, %{id: id, data: %{multiple: false}} = _parameter, value) when is_list(value), do: errors ++ [{"multiple values are not allowed for", id}]
-  defp check_multiple(errors, %{id: id, data: %{multiple: true}} = parameter, value) when not is_list(value), do: check_multiple(errors, parameter, [value])
-  defp check_multiple(errors, %{id: id, arke_id: type, data: %{ multiple: true}} = parameter, value) do
-    case check_values_type(value,type) do
-      true -> errors
+  defp check_multiple(errors, %{id: id, data: %{multiple: false}} = _parameter, value)
+       when is_list(value),
+       do: errors ++ [{"multiple values are not allowed for", id}]
+
+  defp check_multiple(errors, %{id: id, data: %{multiple: true}} = parameter, value)
+       when not is_list(value),
+       do: check_multiple(errors, parameter, [value])
+
+  defp check_multiple(
+         errors,
+         %{id: id, arke_id: type, data: %{multiple: true}} = parameter,
+         value
+       ) do
+    case check_values_type(value, type) do
+      true ->
+        errors
+
       false ->
-        errors ++ [{"[#{Enum.join(value,",")}]", "#{id} must be a list of #{type} "}]
+        errors ++ [{"[#{Enum.join(value, ",")}]", "#{id} must be a list of #{type} "}]
     end
   end
-  defp check_multiple(errors,_parameter,_value), do: errors
+
+  defp check_multiple(errors, _parameter, _value), do: errors
   # --- end Multiple ---
 
   defp check_whitespace(%{data: %{strip: true}} = parameter, value) when is_atom(value) do
@@ -353,7 +370,8 @@ defmodule Arke.Validator do
          value
        ) do
     # todo: used to parse override in metadata which can be written as string
-    max = parse_value(%{arke_id: :integer, data: %{multiple: false}},max_length)
+    max = parse_value(%{arke_id: :integer, data: %{multiple: false}}, max_length)
+
     if String.length(value) > max do
       errors ++ [{label, "max length is #{max_length}"}]
     else
@@ -371,7 +389,8 @@ defmodule Arke.Validator do
          value
        ) do
     # todo: used to parse override in metadata which can be written as string
-    min = parse_value(%{arke_id: :integer, data: %{multiple: false}},min_length)
+    min = parse_value(%{arke_id: :integer, data: %{multiple: false}}, min_length)
+
     if String.length(value) < min do
       errors ++ [{label, "min length is #{min_length}"}]
     else
@@ -420,7 +439,8 @@ defmodule Arke.Validator do
   defp check_max(errors, %{data: %{max: max}} = parameter, _) when is_nil(max), do: errors
 
   defp check_max(errors, %{data: %{max: max, label: label}} = parameter, value) do
-    parsed_max = parse_value(parameter,max)
+    parsed_max = parse_value(parameter, max)
+
     if value > parsed_max do
       errors ++ [{label, "max is #{max}"}]
     else
@@ -431,7 +451,8 @@ defmodule Arke.Validator do
   defp check_min(errors, %{data: %{min: min}} = parameter, _) when is_nil(min), do: errors
 
   defp check_min(errors, %{data: %{min: min, label: label}} = parameter, value) do
-    parsed_min = parse_value(parameter,min)
+    parsed_min = parse_value(parameter, min)
+
     if value < parsed_min do
       errors ++ [{label, "min is #{min}"}]
     else

--- a/lib/examples/starter.ex
+++ b/lib/examples/starter.ex
@@ -14,8 +14,8 @@
 
 defmodule Arke.Examples.Starter do
   @moduledoc """
-               Module to start all the defaults gen server
-             """
+    Module to start all the defaults gen server
+  """
   alias Arke.Boundary.{ArkeManager}
 
   @doc """
@@ -78,5 +78,4 @@ defmodule Arke.Examples.Starter do
       ArkeManager.add_parameter(parent_id, :arke_system, child_id, data.metadata)
     end)
   end
-
 end

--- a/lib/mix/tasks/arke.seed_project.ex
+++ b/lib/mix/tasks/arke.seed_project.ex
@@ -354,7 +354,7 @@ defmodule Mix.Tasks.Arke.SeedProject do
       parameter_errors = handle_list_errors(link_parameter_error, parameter_error_msg, error)
       handle_arke(t, project, parameter_errors)
     else
-     %Unit{} = arke_model ->
+      %Unit{} = arke_model ->
         Mix.shell().info("--- Updating parameters for arke #{id} --- ")
 
         handle_arke_parameters(arke_model, parameter)
@@ -480,14 +480,14 @@ defmodule Mix.Tasks.Arke.SeedProject do
   end
 
   defp handle_group_members(%{metadata: %{project: project}} = current_group_model, arke_list) do
-
     arke_to_remove_ids = current_group_model.data.arke_list -- arke_list
     arke_to_add_ids = arke_list -- current_group_model.data.arke_list
 
     # every group has a `arke_list` field that stores the arke ids it contains.
     # Must be updated and the link will be handled automatically
     complete_arke_list =
-      ((current_group_model.data.arke_list -- arke_to_remove_ids) ++ arke_to_add_ids) |> Enum.uniq()
+      ((current_group_model.data.arke_list -- arke_to_remove_ids) ++ arke_to_add_ids)
+      |> Enum.uniq()
 
     QueryManager.get_by(project: project, id: current_group_model.id)
     |> QueryManager.update(arke_list: complete_arke_list)
@@ -512,7 +512,6 @@ defmodule Mix.Tasks.Arke.SeedProject do
     do: {to_string(child_id), Map.get(child, :metadata, %{})}
 
   defp get_link_data(child_id), do: {to_string(child_id), %{}}
-
 
   defp parse_error({:error, error_message}, error_accumulator) when is_list(error_message),
     do: error_message ++ error_accumulator

--- a/test/support/create_arke.ex
+++ b/test/support/create_arke.ex
@@ -12,7 +12,10 @@ defmodule Arke.Test.CreateArke do
       unique: true
     )
 
-    parameter(:enum_string_support, :string, required: false, values: ["first", "second", "third"])
+    parameter(:enum_string_support, :string,
+      required: false,
+      values: ["first", "second", "third"]
+    )
 
     parameter(:integer_support, :integer, required: false, default_integer: 5)
 

--- a/test/support/fixtures/gcs_requests.exs
+++ b/test/support/fixtures/gcs_requests.exs
@@ -116,7 +116,8 @@
   get_dated_path: %{
     body: %{body: nil, kind: :raw},
     query: [],
-    url: "https://storage.googleapis.com/storage/v1/b/probe-bucket/o/arke_file%2F2026-08-03%2010%3A11%3A12.345678Z%2Fmy%20file.png",
+    url:
+      "https://storage.googleapis.com/storage/v1/b/probe-bucket/o/arke_file%2F2026-08-03%2010%3A11%3A12.345678Z%2Fmy%20file.png",
     headers: [
       {"accept-encoding", "gzip, deflate, identity"},
       {"authorization", "Bearer test-token"}
@@ -146,7 +147,8 @@
   delete_dated_path: %{
     body: %{body: "", kind: :raw},
     query: [],
-    url: "https://storage.googleapis.com/storage/v1/b/probe-bucket/o/arke_file%2F2026-08-03%2010%3A11%3A12.345678Z%2Fmy%20file.png",
+    url:
+      "https://storage.googleapis.com/storage/v1/b/probe-bucket/o/arke_file%2F2026-08-03%2010%3A11%3A12.345678Z%2Fmy%20file.png",
     headers: [
       {"accept-encoding", "gzip, deflate, identity"},
       {"authorization", "Bearer test-token"}

--- a/test/support/gcp.ex
+++ b/test/support/gcp.ex
@@ -43,7 +43,8 @@ defmodule Arke.Test.Gcp do
       method: request.method,
       url: request.url |> struct(query: nil) |> URI.to_string(),
       query: URI.decode_query(request.url.query || ""),
-      headers: request |> Req.get_headers_list() |> reject_framing_headers() |> normalize_headers(),
+      headers:
+        request |> Req.get_headers_list() |> reject_framing_headers() |> normalize_headers(),
       body: project_request_body(request)
     }
   end

--- a/test/utils/gcp/auth_test.exs
+++ b/test/utils/gcp/auth_test.exs
@@ -14,7 +14,8 @@ defmodule Arke.Utils.Gcp.AuthTest do
   setup do
     # Nothing must leak in from the machine running the suite, including its
     # gcloud ADC file: CLOUDSDK_CONFIG points the lookup at an empty dir.
-    for var <- ~w[GOOGLE_APPLICATION_CREDENTIALS GOOGLE_APPLICATION_CREDENTIALS_JSON CLOUDSDK_CONFIG] do
+    for var <-
+          ~w[GOOGLE_APPLICATION_CREDENTIALS GOOGLE_APPLICATION_CREDENTIALS_JSON CLOUDSDK_CONFIG] do
       previous = System.get_env(var)
       System.delete_env(var)
 
@@ -52,7 +53,9 @@ defmodule Arke.Utils.Gcp.AuthTest do
   end
 
   defp put_credentials_file(json) do
-    path = Path.join(System.tmp_dir!(), "arke-credentials-#{System.unique_integer([:positive])}.json")
+    path =
+      Path.join(System.tmp_dir!(), "arke-credentials-#{System.unique_integer([:positive])}.json")
+
     File.write!(path, json)
     System.put_env("GOOGLE_APPLICATION_CREDENTIALS", path)
     on_exit(fn -> File.rm(path) end)
@@ -162,7 +165,10 @@ defmodule Arke.Utils.Gcp.AuthTest do
     setup do
       account = TestGcp.service_account()
       # The env var must lose to application config.
-      put_credentials_file(service_account_json(TestGcp.service_account("env@project.iam.gserviceaccount.com")))
+      put_credentials_file(
+        service_account_json(TestGcp.service_account("env@project.iam.gserviceaccount.com"))
+      )
+
       {:ok, account: account}
     end
 

--- a/test/utils/gcp_equivalence_test.exs
+++ b/test/utils/gcp_equivalence_test.exs
@@ -80,5 +80,4 @@ defmodule Arke.Utils.GcpEquivalenceTest do
       assert MapSet.new(Map.keys(fixtures)) == MapSet.new(@cases)
     end
   end
-
 end


### PR DESCRIPTION
## Description

Adds a `mix format --check-formatted` step to CI, guarded by a `lint` flag on the
1.18.4 matrix leg, plus the mechanical format pass it requires.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works
