### PR TITLE
feat: per-project file buckets

### DIFF
--- a/lib/arke/core/file.ex
+++ b/lib/arke/core/file.ex
@@ -21,6 +21,7 @@ defmodule Arke.Core.File do
 
   alias Arke.Boundary.FileManager
   alias Arke.Hook
+  alias Arke.QueryManager
   require Logger
 
   def file_storage_module(), do: Application.get_env(:arke, :file_storage_module, Arke.Utils.Gcp)
@@ -38,8 +39,8 @@ defmodule Arke.Core.File do
     {:ok, hook}
   end
 
-  defp remove_uploaded(%Hook{unit: %{data: %{name: name, path: path}}} = hook) do
-    file_storage_module().delete_file("#{path}/#{name}")
+  defp remove_uploaded(%Hook{unit: %{data: %{name: name, path: path} = data}} = hook) do
+    file_storage_module().delete_file("#{path}/#{name}", bucket: data[:bucket])
     {:ok, hook}
   end
 
@@ -86,29 +87,52 @@ defmodule Arke.Core.File do
   defp upload(
          %Hook{
            unit:
-             %{data: %{name: name, path: path, binary_data: binary}, runtime_data: runtime_data} =
-               unit
+             %{
+               data: %{name: name, path: path, binary_data: binary},
+               metadata: %{project: project},
+               runtime_data: runtime_data
+             } = unit
          } = hook
        ) do
     is_public_file = is_public?(runtime_data)
+    bucket = resolve_bucket(runtime_data, project)
+    path = "#{project}/#{path}"
 
     new_unit =
-      Map.update(unit, :data, unit.data, fn udata -> Map.put(udata, :public, is_public_file) end)
+      Map.update(unit, :data, unit.data, fn udata ->
+        Map.merge(udata, %{public: is_public_file, bucket: bucket, path: path})
+      end)
 
-    case file_storage_module().upload_file("#{path}/#{name}", binary, public: is_public_file) do
+    case file_storage_module().upload_file("#{path}/#{name}", binary,
+           public: is_public_file,
+           bucket: bucket
+         ) do
       {:ok, _object} -> {:ok, %{hook | unit: new_unit}}
       {:error, error} -> {:error, error}
     end
   end
 
-  defp delete_stored_file(%Hook{unit: %{data: %{name: name, path: path}}} = hook) do
-    case file_storage_module().delete_file("#{path}/#{name}") do
+  defp resolve_bucket(%{link_parameter: %{data: %{bucket: bucket}}}, _project)
+       when is_binary(bucket),
+       do: bucket
+
+  defp resolve_bucket(_runtime_data, project) do
+    case QueryManager.get_by(project: :arke_system, arke_id: :arke_project, id: project) do
+      %{data: %{bucket: bucket}} when is_binary(bucket) -> bucket
+      _ -> nil
+    end
+  end
+
+  defp delete_stored_file(%Hook{unit: %{data: %{name: name, path: path} = data}} = hook) do
+    case file_storage_module().delete_file("#{path}/#{name}", bucket: data[:bucket]) do
       {:ok, _e} -> {:ok, hook}
       {:error, error} -> {:error, error}
     end
   end
 
-  def get_url(%{data: %{public: true}} = unit), do: file_storage_module().get_public_url(unit)
+  def get_url(%{data: %{public: true} = data} = unit),
+    do: file_storage_module().get_public_url(unit, bucket: data[:bucket])
+
   def get_url(unit), do: get_signed_url(unit)
 
   def get_signed_url(%{data: data, id: unit_id, metadata: %{project: project}} = unit) do
@@ -118,7 +142,9 @@ defmodule Arke.Core.File do
       {:ok, result}
     else
       _ ->
-        case file_storage_module().get_bucket_file_signed_url("#{data.path}/#{data.name}") do
+        case file_storage_module().get_bucket_file_signed_url("#{data.path}/#{data.name}",
+               bucket: data[:bucket]
+             ) do
           {:ok, result} ->
             FileManager.add(unit, result)
             {:ok, result}

--- a/lib/arke/query_manager.ex
+++ b/lib/arke/query_manager.ex
@@ -257,8 +257,8 @@ defmodule Arke.QueryManager do
     do: {:ok, parameter, value}
 
   defp execute_write(%Hook{arke: arke} = hook, persist, old_data) do
-    result =
-      with {:ok, hook} <- Pipeline.run(:before_transaction, hook, sources(arke)) do
+    case Pipeline.run(:before_transaction, hook, sources(arke)) do
+      {:ok, hook} ->
         in_transaction(arke, fn ->
           with {:ok, hook} <- Pipeline.run(:before_write, hook, arke_sources(arke)),
                {:ok, hook} <- Pipeline.run(:before_write, hook, group_sources(arke)),
@@ -271,9 +271,11 @@ defmodule Arke.QueryManager do
                  Pipeline.run(:after_write, %{hook | unit: unit}, group_sources(arke)),
                do: {:ok, hook}
         end)
-      end
+        |> finish_write(hook, arke, fn final -> {:ok, final.unit} end)
 
-    finish_write(result, hook, arke, fn final -> {:ok, final.unit} end)
+      {:error, _} = error ->
+        finish_write(error, hook, arke, fn final -> {:ok, final.unit} end)
+    end
   end
 
   defp finish_write(result, hook, arke, on_success) do

--- a/lib/registry/shared/arke.json
+++ b/lib/registry/shared/arke.json
@@ -44,6 +44,12 @@
       "metadata": {
         "required": false
       }
+    },
+    {
+      "id": "bucket",
+      "metadata": {
+        "required": false
+      }
     }
   ]
 }

--- a/lib/registry/shared/parameter.json
+++ b/lib/registry/shared/parameter.json
@@ -90,6 +90,25 @@
     "required": false
   },
   {
+    "default_string": null,
+    "type": "string",
+    "format": "attribute",
+    "helper_text": "Storage bucket",
+    "id": "bucket",
+    "is_primary": false,
+    "label": "Bucket",
+    "max_length": null,
+    "min_length": null,
+    "multiple": false,
+    "nullable": true,
+    "persistence": "arke_parameter",
+    "required": false,
+    "strip": false,
+"lowercase": false,
+    "unique": false,
+    "values": null
+  },
+  {
     "default_string": "",
     "type": "string",
     "format": "attribute",

--- a/lib/registry/system/arke.json
+++ b/lib/registry/system/arke.json
@@ -995,6 +995,12 @@
           "required": true,
           "default_string": "postgres_schema"
         }
+      },
+      {
+        "id": "bucket",
+        "metadata": {
+          "required": false
+        }
       }
     ]
   }

--- a/test/core/file_test.exs
+++ b/test/core/file_test.exs
@@ -1,0 +1,130 @@
+defmodule Arke.Core.FileTest do
+  use Arke.Test.RepoCase
+
+  defmodule Storage do
+    use Arke.Utils.FileStorage
+
+    def upload_file(file_name, _file_data, opts) do
+      send(self(), {:upload, file_name, opts})
+      {:ok, %{}}
+    end
+
+    def delete_file(file_path, opts) do
+      send(self(), {:delete, file_path, opts})
+      {:ok, %{}}
+    end
+
+    def get_bucket_file_signed_url(file_path, opts) do
+      send(self(), {:signed_url, file_path, opts})
+
+      {:ok,
+       %{
+         signed_url: "https://signed",
+         expiration: DateTime.utc_now() |> DateTime.to_unix() |> Kernel.+(3600)
+       }}
+    end
+  end
+
+  @project :file_test_project
+
+  setup do
+    Application.put_env(:arke, :file_storage_module, Storage)
+    on_exit(fn -> Application.delete_env(:arke, :file_storage_module) end)
+    :ok
+  end
+
+  defp project_with_bucket(bucket) do
+    {:ok, _} =
+      QueryManager.create(:arke_system, ArkeManager.get(:arke_project, :arke_system),
+        id: to_string(@project),
+        label: "File test project",
+        type: "postgres_schema",
+        bucket: bucket
+      )
+
+    :ok
+  end
+
+  defp create_file(opts \\ []) do
+    source = Path.join(System.tmp_dir!(), "arke_file_#{System.unique_integer([:positive])}")
+    File.write!(source, "content")
+
+    QueryManager.create(
+      @project,
+      ArkeManager.get(:arke_file, @project),
+      [
+        metadata: %{project: @project},
+        path: source,
+        content_type: "text/plain",
+        filename: "doc.txt"
+      ] ++ opts
+    )
+  end
+
+  describe "upload" do
+    test "stamps the project bucket and project-prefixed path, and passes them to the storage" do
+      project_with_bucket("project-bucket")
+
+      {:ok, unit} = create_file()
+
+      assert unit.data.bucket == "project-bucket"
+      assert String.starts_with?(unit.data.path, "#{@project}/arke_file/")
+
+      assert_received {:upload, name, opts}
+      assert opts[:bucket] == "project-bucket"
+      assert name == "#{unit.data.path}/doc.txt"
+    end
+
+    test "a link_parameter bucket wins over the project bucket" do
+      project_with_bucket("project-bucket")
+
+      {:ok, unit} =
+        create_file(runtime_data: %{link_parameter: %{data: %{bucket: "override-bucket"}}})
+
+      assert unit.data.bucket == "override-bucket"
+      assert_received {:upload, _name, opts}
+      assert opts[:bucket] == "override-bucket"
+    end
+
+    test "no project bucket falls through to nil" do
+      {:ok, unit} = create_file()
+
+      assert unit.data.bucket == nil
+      assert_received {:upload, _name, opts}
+      assert opts[:bucket] == nil
+    end
+  end
+
+  describe "stored bucket" do
+    test "delete passes the stamped bucket" do
+      project_with_bucket("project-bucket")
+      {:ok, unit} = create_file()
+
+      {:ok, nil} = QueryManager.delete(@project, unit)
+
+      assert_received {:delete, path, opts}
+      assert path == "#{unit.data.path}/doc.txt"
+      assert opts[:bucket] == "project-bucket"
+    end
+
+    test "signed url passes the stamped bucket" do
+      project_with_bucket("project-bucket")
+      {:ok, unit} = create_file()
+
+      assert {:ok, %{signed_url: "https://signed"}} = Arke.Core.File.get_signed_url(unit)
+
+      assert_received {:signed_url, _path, opts}
+      assert opts[:bucket] == "project-bucket"
+    end
+
+    test "a legacy unit with no stamped bucket signs against nil" do
+      {:ok, unit} = create_file()
+      legacy = %{unit | id: :legacy_file, data: Map.delete(unit.data, :bucket)}
+
+      assert {:ok, _} = Arke.Core.File.get_signed_url(legacy)
+
+      assert_received {:signed_url, _path, opts}
+      assert opts[:bucket] == nil
+    end
+  end
+end

--- a/usage-rules/defining_arkes.md
+++ b/usage-rules/defining_arkes.md
@@ -57,8 +57,10 @@
     home for effects (email, push, Tasks, cache sync). It cannot mutate the
     persisted row.
   - `after_rollback`: after rollback, failure only — compensation
-    (`hook.error` carries the reason). Both post-outcome slots are isolated:
-    a raising entry is logged and never changes the caller's result.
+    (`hook.error` carries the reason). `hook.unit` is the unit as
+    `before_transaction` left it, so a compensator can undo what that hook
+    staged. Both post-outcome slots are isolated: a raising entry is logged
+    and never changes the caller's result.
 - Read/build-path hooks stay overridable callback heads: `before_load/2`,
   `after_load/2`, `before_validate/2`, `after_validate/2`,
   `before_struct_encode/2`, `after_struct_encode/4`, `after_get_struct/2`.

--- a/usage-rules/setup.md
+++ b/usage-rules/setup.md
@@ -54,6 +54,12 @@
   → `GOOGLE_APPLICATION_CREDENTIALS_JSON` (inline JSON) → gcloud ADC
   (`application_default_credentials.json` in `$CLOUDSDK_CONFIG`, defaulting to
   `~/.config/gcloud`) → GCE metadata.
+- Per-project buckets: set `bucket` on the `arke_project` unit; a link
+  parameter's `bucket` metadata overrides it. It is resolved once at upload and
+  stamped on the file unit, so reads and deletes use the stored value and unset
+  means `DEFAULT_BUCKET`. Ops provisions the bucket and grants the service
+  account access — arke never creates one. New object keys are
+  `<project>/arke_file/<timestamp>/<name>`.
 - Signed URLs (V2) are signed with the service account private key, so they need
   service-account JSON credentials: metadata server and gcloud user credentials
   have no key to sign with and return `{:error, "error on signed url"}`. The


### PR DESCRIPTION
## Description

A project can have its own GCS bucket. The bucket is resolved once at upload and stamped on the file unit next to `provider`, so reads and deletes use the stored value and legacy files keep falling through to `DEFAULT_BUCKET` with no backfill.

Resolution order at upload: the link parameter's `bucket` metadata, then the project unit's `bucket`, then nil. The link parameter channel is the one that already carries `public`, so more than one bucket per project comes for free.

Object paths gain a project prefix (`<project>/arke_file/<timestamp>`), namespacing projects that stay in the default bucket.

Bucket provisioning stays out of band: ops creates the bucket, grants the service account access and sets `bucket` on the project unit. Existing deployments need `mix arke.seed_project` re-run to pick up the new parameter.

Also fixes `execute_write`, which handed `after_rollback` the hook as it stood before `before_transaction` ran. A compensator undoes what `before_transaction` did, so it has to see that unit. Without this the file compensator deletes an unprefixed key in the wrong bucket and leaks the uploaded object.

Stacked on #168.

## Related Issue

None.

## Docs
- [x] I have updated the docs accordingly

## Test
- [x] I have added tests that prove my fix is effective or that my feature works
