### PR TITLE
fix: register a created group with its own arke_list

### DIFF
--- a/lib/arke/core/group.ex
+++ b/lib/arke/core/group.ex
@@ -25,7 +25,7 @@ defmodule Arke.Core.Group do
   arke do
   end
 
-  after_write(:normalize_arke_list, on: :update)
+  after_write(:normalize_arke_list, on: [:create, :update])
   after_commit(:sync_manager)
 
   defp normalize_arke_list(%Hook{unit: %{data: data} = unit} = hook) do
@@ -38,8 +38,7 @@ defmodule Arke.Core.Group do
   end
 
   defp sync_manager(%Hook{op: :create, unit: unit} = hook) do
-    group = Unit.update(unit, arke_list: [])
-    GroupManager.create(group)
+    GroupManager.create(unit)
     {:ok, hook}
   end
 

--- a/test/core/group_test.exs
+++ b/test/core/group_test.exs
@@ -16,6 +16,19 @@ defmodule Arke.Core.GroupTest do
       assert after_create.id == :group_test
     end
 
+    test "create with arke_list registers the members in the manager" do
+      group_model = ArkeManager.get(:group, :arke_system)
+
+      QueryManager.create(:test_schema, group_model, %{
+        id: "group_test_members",
+        name: "group_test_members",
+        arke_list: ["arke_test_support"]
+      })
+
+      members = GroupManager.get(:group_test_members, :test_schema).data.arke_list
+      assert Enum.map(members, & &1.id) == [:arke_test_support]
+    end
+
     test "delete" do
       group_model = ArkeManager.get(:group, :arke_system)
 


### PR DESCRIPTION
## Description

Since #168, creating a group with its `arke_list` leaves the GroupManager entry empty: the nested `arke_link` after_commit syncs run before the group itself is registered, so their `add_link` calls no-op, and `sync_manager(:create)` then registers a blanked list. DB rows are correct; a project seeded on a running node has empty group membership until reboot.

- run `normalize_arke_list` on `:create` too
- register the created unit as-is, like `Arke.Core.Arke` does

## Docs

- [ ] I have updated the docs accordingly

## Test

- [x] I have added tests that prove my fix is effective or that my feature works