### PR TITLE
fix: normalize unit metadata keys to atoms in the constructor

### DIFF
--- a/lib/arke/core/unit.ex
+++ b/lib/arke/core/unit.ex
@@ -44,7 +44,7 @@ defmodule Arke.Core.Unit do
           data: data,
           arke_id: arke_id,
           link: link,
-          metadata: metadata,
+          metadata: normalize_metadata(metadata),
           inserted_at: DatetimeHandler.parse_datetime(inserted_at, true),
           updated_at: DatetimeHandler.parse_datetime(updated_at, true),
           __module__: module,
@@ -52,6 +52,26 @@ defmodule Arke.Core.Unit do
         )
     end
   end
+
+  defp normalize_metadata(nil), do: nil
+
+  defp normalize_metadata(metadata) when is_map(metadata) do
+    {atoms, strings} = Map.split_with(metadata, fn {key, _value} -> is_atom(key) end)
+
+    strings
+    |> Map.new(fn {key, value} -> {existing_atom(key), value} end)
+    |> Map.merge(atoms)
+  end
+
+  defp normalize_metadata(metadata), do: metadata
+
+  defp existing_atom(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+
+  defp existing_atom(key), do: key
 
   defp check_id(id) when is_binary(id), do: String.to_atom(id)
   defp check_id(id) when is_atom(id), do: id

--- a/test/core/unit_test.exs
+++ b/test/core/unit_test.exs
@@ -1,6 +1,30 @@
 defmodule Arke.Core.UnitTest do
   use Arke.Test.RepoCase
 
+  describe "metadata normalization" do
+    test "string keys become atoms, unknown keys and values stay untouched" do
+      metadata = %{
+        "transaction" => false,
+        "not_an_existing_atom_key_xyz" => 1,
+        "nested" => %{"inner" => 1}
+      }
+
+      unit = Unit.new(:unit_meta_norm, [], :arke, nil, metadata, nil, nil, __MODULE__)
+
+      assert unit.metadata[:transaction] == false
+      assert unit.metadata["not_an_existing_atom_key_xyz"] == 1
+      assert unit.metadata[:nested] == %{"inner" => 1}
+      refute Map.has_key?(unit.metadata, "transaction")
+    end
+
+    test "the atom entry wins over a stale string duplicate" do
+      metadata = %{"project" => "stale_string", :project => :test_schema}
+      unit = Unit.new(:unit_meta_collision, [], :arke, nil, metadata, nil, nil, __MODULE__)
+
+      assert unit.metadata == %{project: :test_schema}
+    end
+  end
+
   describe "Unit" do
     test "new" do
       # id, data, arke_id, link, metadata, inserted_at, updated_at, __module__

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -169,6 +169,21 @@ defmodule Arke.TransactionTest do
     end
   end
 
+  test "a string-keyed transaction flag, as reloaded from jsonb, still opts out" do
+    arke =
+      Arke.Core.Unit.update(hook_arke(), %{
+        metadata: Map.put(hook_arke().metadata, "transaction", false)
+      })
+
+    assert {:error, [%{message: "failed after write"}]} =
+             QueryManager.create(@project, arke,
+               id: "txn_string_optout",
+               hook_flag: "fail_after_write"
+             )
+
+    assert QueryManager.get_by(project: @project, id: "txn_string_optout") != nil
+  end
+
   test "after_commit still flushes for a transaction-opted-out arke" do
     arke_project = ArkeManager.get(:arke_project, :arke_system)
 


### PR DESCRIPTION
## Description

Metadata reloaded from jsonb comes back with string keys, so the `:transaction` opt-out on arke_project is never read after boot and project creation fails with "cannot create project schema".

This makes atom keys the canonical metadata shape, enforced once in `Unit.new/9` where every load path converges. Strings convert via `String.to_existing_atom` (unknown keys stay strings), normalization is shallow, and on a stale string duplicate the atom entry wins.

Breaking for consumers that read `unit.metadata` with string keys after a load: those keys are now atoms when a matching atom exists.

Supersedes arkemis/arke-postgres#77, which patched only the boot-time parse in the postgres adapter.

## Related Issue

Supersedes arkemis/arke-postgres#77

## Docs
- [ ] I have updated the docs accordingly

## Test

- [x] I have added tests that prove my fix is effective or that my feature works
